### PR TITLE
Add optional Gibbons–Hawking time wear mode

### DIFF
--- a/include/background.h
+++ b/include/background.h
@@ -123,6 +123,12 @@ struct background
   enum varconst_dependence varconst_dep; /**< dependence of the varying fundamental constants as a function of time */
   double varconst_transition_redshift; /**< redshift of transition between varied fundamental constants and normal fundamental constants in the 'varconst_instant' case*/
 
+  /* --- Gibbons-Hawking time wear parameters --- */
+  short use_time_wear_GH; /**< flag for activating Gibbons-Hawking time wear */
+  double alpha_GH; /**< amplitude of time wear */
+  double time_wear_GH_a_t; /**< late-time switch scale factor */
+  double time_wear_GH_m;   /**< steepness of late-time switch */
+
   //@}
 
 
@@ -252,6 +258,7 @@ struct background
 
   //@{
 
+  int index_bi_rho_cdm; /**< {B} cdm density with time wear */
   int index_bi_rho_dcdm;/**< {B} dcdm density */
   int index_bi_rho_dr;  /**< {B} dr density */
   int index_bi_rho_fld; /**< {B} fluid density */

--- a/source/background.c
+++ b/source/background.c
@@ -437,7 +437,7 @@ int background_functions(
   /* cdm */
   if (pba->has_cdm == _TRUE_) {
     if (pba->use_time_wear_GH == _TRUE_) {
-      pvecback[pba->index_bg_rho_cdm] = pvecback_B[pba->index_bi_rho_cdm];
+      pvecback[pba->index_bg_rho_cdm] = exp(pvecback_B[pba->index_bi_rho_cdm]);
     }
     else {
       pvecback[pba->index_bg_rho_cdm] = pba->Omega0_cdm * pow(pba->H0,2) / pow(a,3);
@@ -2007,7 +2007,7 @@ int background_solve(
     pba->Omega0_dr = pvecback_integration[pba->index_bi_rho_dr]/pba->H0/pba->H0;
   }
   if (pba->use_time_wear_GH == _TRUE_) {
-    pba->Omega0_cdm = pvecback_integration[pba->index_bi_rho_cdm]/pba->H0/pba->H0;
+    pba->Omega0_cdm = exp(pvecback_integration[pba->index_bi_rho_cdm])/pba->H0/pba->H0;
   }
   /* -> scale-invariant growth rate today */
   D_today = pvecback_integration[pba->index_bi_D];
@@ -2230,7 +2230,7 @@ int background_initial_conditions(
   }
 
   if (pba->use_time_wear_GH == _TRUE_) {
-    pvecback_integration[pba->index_bi_rho_cdm] = pba->Omega0_cdm*pba->H0*pba->H0*pow(a,-3);
+    pvecback_integration[pba->index_bi_rho_cdm] = log(pba->Omega0_cdm*pba->H0*pba->H0*pow(a,-3));
   }
   if (pba->has_dcdm == _TRUE_) {
     /* Remember that the critical density today in CLASS conventions is H0^2 */
@@ -2664,7 +2664,7 @@ int background_derivs(
   if (pba->use_time_wear_GH == _TRUE_) {
     double S = pba->alpha_GH * H / pba->H0;
     S /= 1.+pow(pba->time_wear_GH_a_t/a, pba->time_wear_GH_m);
-    dy[pba->index_bi_rho_cdm] = -(3.+S)*y[pba->index_bi_rho_cdm];
+    dy[pba->index_bi_rho_cdm] = -(3.+S);
   }
 
   if (pba->has_dcdm == _TRUE_) {

--- a/source/background.c
+++ b/source/background.c
@@ -2663,9 +2663,7 @@ int background_derivs(
 
   if (pba->use_time_wear_GH == _TRUE_) {
     double S = pba->alpha_GH * H / pba->H0;
-    if (pba->time_wear_GH_a_t > 0.) {
-      S /= 1.+pow(pba->time_wear_GH_a_t/a, pba->time_wear_GH_m);
-    }
+    S /= 1.+pow(pba->time_wear_GH_a_t/a, pba->time_wear_GH_m);
     dy[pba->index_bi_rho_cdm] = -(3.+S)*y[pba->index_bi_rho_cdm];
   }
 

--- a/source/background.c
+++ b/source/background.c
@@ -436,7 +436,12 @@ int background_functions(
 
   /* cdm */
   if (pba->has_cdm == _TRUE_) {
-    pvecback[pba->index_bg_rho_cdm] = pba->Omega0_cdm * pow(pba->H0,2) / pow(a,3);
+    if (pba->use_time_wear_GH == _TRUE_) {
+      pvecback[pba->index_bg_rho_cdm] = pvecback_B[pba->index_bi_rho_cdm];
+    }
+    else {
+      pvecback[pba->index_bg_rho_cdm] = pba->Omega0_cdm * pow(pba->H0,2) / pow(a,3);
+    }
     rho_tot += pvecback[pba->index_bg_rho_cdm];
     p_tot += 0.;
     rho_m += pvecback[pba->index_bg_rho_cdm];
@@ -1156,6 +1161,9 @@ int background_indices(
   /* -> index for conformal time in vector of variables to integrate */
   class_define_index(pba->index_bi_tau,_TRUE_,index_bi,1);
 
+  /* -> energy density in CDM if time wear is enabled */
+  class_define_index(pba->index_bi_rho_cdm,pba->use_time_wear_GH,index_bi,1);
+
   /* -> energy density in DCDM */
   class_define_index(pba->index_bi_rho_dcdm,pba->has_dcdm,index_bi,1);
 
@@ -1801,6 +1809,13 @@ int background_checks(
   /** - in verbose mode, send to standard output some additional information on non-obvious background parameters */
   if (pba->background_verbose > 0) {
 
+    if (pba->background_verbose >= 2 && pba->use_time_wear_GH == _TRUE_) {
+      printf(" -> Gibbons-Hawking time wear activated with alpha_GH = %g\n", pba->alpha_GH);
+      if (pba->time_wear_GH_a_t > 0.) {
+        printf("    switch parameters a_t = %g m = %g\n", pba->time_wear_GH_a_t, pba->time_wear_GH_m);
+      }
+    }
+
     if (pba->has_ncdm == _TRUE_) {
 
       /* loop over ncdm species */
@@ -1990,6 +2005,9 @@ int background_solve(
   }
   if (pba->has_dr == _TRUE_) {
     pba->Omega0_dr = pvecback_integration[pba->index_bi_rho_dr]/pba->H0/pba->H0;
+  }
+  if (pba->use_time_wear_GH == _TRUE_) {
+    pba->Omega0_cdm = pvecback_integration[pba->index_bi_rho_cdm]/pba->H0/pba->H0;
   }
   /* -> scale-invariant growth rate today */
   D_today = pvecback_integration[pba->index_bi_D];
@@ -2209,6 +2227,10 @@ int background_initial_conditions(
   if (pba->has_ncdm == _TRUE_) {
     /** - We must add the relativistic contribution from NCDM species */
     rho_rad += rho_ncdm_rel_tot;
+  }
+
+  if (pba->use_time_wear_GH == _TRUE_) {
+    pvecback_integration[pba->index_bi_rho_cdm] = pba->Omega0_cdm*pba->H0*pba->H0*pow(a,-3);
   }
   if (pba->has_dcdm == _TRUE_) {
     /* Remember that the critical density today in CLASS conventions is H0^2 */
@@ -2638,6 +2660,14 @@ int background_derivs(
 
   dy[pba->index_bi_D] = y[pba->index_bi_D_prime]/a/H;
   dy[pba->index_bi_D_prime] = -y[pba->index_bi_D_prime] + 1.5*a*rho_M*y[pba->index_bi_D]/H;
+
+  if (pba->use_time_wear_GH == _TRUE_) {
+    double S = pba->alpha_GH * H / pba->H0;
+    if (pba->time_wear_GH_a_t > 0.) {
+      S /= 1.+pow(pba->time_wear_GH_a_t/a, pba->time_wear_GH_m);
+    }
+    dy[pba->index_bi_rho_cdm] = -(3.+S)*y[pba->index_bi_rho_cdm];
+  }
 
   if (pba->has_dcdm == _TRUE_) {
     /** - compute dcdm density \f$ d\rho/dloga = -3 \rho - \Gamma/H \rho \f$*/

--- a/source/input.c
+++ b/source/input.c
@@ -5923,8 +5923,8 @@ int input_default_params(struct background *pba,
   /* Gibbons-Hawking time wear defaults */
   pba->use_time_wear_GH = _FALSE_;
   pba->alpha_GH = 0.;
-  pba->time_wear_GH_a_t = 0.;
-  pba->time_wear_GH_m = 1.;
+  pba->time_wear_GH_a_t = 0.3;
+  pba->time_wear_GH_m = 6.;
   /** 9.a.2) Equation of state */
   pba->fluid_equation_of_state = CLP;
   pba->w0_fld = -1.;

--- a/source/input.c
+++ b/source/input.c
@@ -3371,6 +3371,16 @@ int input_read_parameters_species(struct file_content * pfc,
     }
   }
 
+  /** 9) Optional Gibbons-Hawking time wear */
+  class_read_flag("use_time_wear_GH",pba->use_time_wear_GH);
+  class_read_double("alpha_GH",pba->alpha_GH);
+  class_read_double("a_t",pba->time_wear_GH_a_t);
+  class_read_double("m",pba->time_wear_GH_m);
+  class_test(pba->alpha_GH < 0.0, errmsg, "alpha_GH must be >= 0");
+  if (pba->alpha_GH > 0.1) {
+    printf("[Warning] alpha_GH=%g > 0.1 may lead to instabilities\n",pba->alpha_GH);
+  }
+
   return _SUCCESS_;
 
 }
@@ -5909,6 +5919,12 @@ int input_default_params(struct background *pba,
   /** 8.a.1) PPF approximation */
   pba->use_ppf = _TRUE_;
   pba->c_gamma_over_c_fld = 0.4;
+
+  /* Gibbons-Hawking time wear defaults */
+  pba->use_time_wear_GH = _FALSE_;
+  pba->alpha_GH = 0.;
+  pba->time_wear_GH_a_t = 0.;
+  pba->time_wear_GH_m = 1.;
   /** 9.a.2) Equation of state */
   pba->fluid_equation_of_state = CLP;
   pba->w0_fld = -1.;

--- a/source/perturbations.c
+++ b/source/perturbations.c
@@ -9220,10 +9220,21 @@ int perturbations_derivs(double tau,
 
     if (pba->has_cdm == _TRUE_) {
 
+      double S_cdm = 0.;
+      if (pba->use_time_wear_GH == _TRUE_) {
+        double a = ppw->pvecback[pba->index_bg_a];
+        double H = ppw->pvecback[pba->index_bg_H];
+        S_cdm = pba->alpha_GH * H / pba->H0;
+        if (pba->time_wear_GH_a_t > 0.) {
+          S_cdm /= 1.+pow(pba->time_wear_GH_a_t/a, pba->time_wear_GH_m);
+        }
+        S_cdm *= a*H;
+      }
+
       /** - ----> newtonian gauge: cdm density and velocity */
 
       if (ppt->gauge == newtonian) {
-        dy[pv->index_pt_delta_cdm] = -(y[pv->index_pt_theta_cdm]+metric_continuity); /* cdm density */
+        dy[pv->index_pt_delta_cdm] = -(y[pv->index_pt_theta_cdm]+metric_continuity) - S_cdm*y[pv->index_pt_delta_cdm]; /* cdm density */
 
         dy[pv->index_pt_theta_cdm] = - a_prime_over_a*y[pv->index_pt_theta_cdm] + metric_euler; /* cdm velocity */
       }
@@ -9231,7 +9242,7 @@ int perturbations_derivs(double tau,
       /** - ----> synchronous gauge: cdm density only (velocity set to zero by definition of the gauge) */
 
       if (ppt->gauge == synchronous) {
-        dy[pv->index_pt_delta_cdm] = -metric_continuity; /* cdm density */
+        dy[pv->index_pt_delta_cdm] = -metric_continuity - S_cdm*y[pv->index_pt_delta_cdm]; /* cdm density */
       }
     }
 

--- a/source/perturbations.c
+++ b/source/perturbations.c
@@ -9224,9 +9224,12 @@ int perturbations_derivs(double tau,
       if (pba->use_time_wear_GH == _TRUE_) {
         double a = ppw->pvecback[pba->index_bg_a];
         double H = ppw->pvecback[pba->index_bg_H];
-        S_cdm = pba->alpha_GH * H / pba->H0;
-        S_cdm /= 1.+pow(pba->time_wear_GH_a_t/a, pba->time_wear_GH_m);
-        S_cdm *= a*H;
+        double rho_cdm = ppw->pvecback[pba->index_bg_rho_cdm];
+        if (rho_cdm > 0.) {
+          S_cdm = pba->alpha_GH * H / pba->H0;
+          S_cdm /= 1.+pow(pba->time_wear_GH_a_t/a, pba->time_wear_GH_m);
+          S_cdm *= a*H;
+        }
       }
 
       /** - ----> newtonian gauge: cdm density and velocity */

--- a/source/perturbations.c
+++ b/source/perturbations.c
@@ -9225,9 +9225,7 @@ int perturbations_derivs(double tau,
         double a = ppw->pvecback[pba->index_bg_a];
         double H = ppw->pvecback[pba->index_bg_H];
         S_cdm = pba->alpha_GH * H / pba->H0;
-        if (pba->time_wear_GH_a_t > 0.) {
-          S_cdm /= 1.+pow(pba->time_wear_GH_a_t/a, pba->time_wear_GH_m);
-        }
+        S_cdm /= 1.+pow(pba->time_wear_GH_a_t/a, pba->time_wear_GH_m);
         S_cdm *= a*H;
       }
 


### PR DESCRIPTION
## Summary
- add configuration parameters for Gibbons–Hawking time wear and optional late-time switch
- evolve CDM density and perturbations with GH wear term
- surface activation summary when `background_verbose>=2`

## Testing
- `make`
- `./class explanatory.ini`

------
https://chatgpt.com/codex/tasks/task_e_68af09713ae48333b87f3525871a29c7