### PR TITLE
Prevent negative CDM densities in solver

### DIFF
--- a/include/background.h
+++ b/include/background.h
@@ -252,6 +252,7 @@ struct background
 
   //@{
 
+  int index_bi_lnrho_cdm;/**< {B} log of cdm density */
   int index_bi_rho_dcdm;/**< {B} dcdm density */
   int index_bi_rho_dr;  /**< {B} dr density */
   int index_bi_rho_fld; /**< {B} fluid density */

--- a/source/background.c
+++ b/source/background.c
@@ -436,7 +436,7 @@ int background_functions(
 
   /* cdm */
   if (pba->has_cdm == _TRUE_) {
-    pvecback[pba->index_bg_rho_cdm] = pba->Omega0_cdm * pow(pba->H0,2) / pow(a,3);
+    pvecback[pba->index_bg_rho_cdm] = exp(pvecback_B[pba->index_bi_lnrho_cdm]);
     rho_tot += pvecback[pba->index_bg_rho_cdm];
     p_tot += 0.;
     rho_m += pvecback[pba->index_bg_rho_cdm];
@@ -1155,6 +1155,9 @@ int background_indices(
 
   /* -> index for conformal time in vector of variables to integrate */
   class_define_index(pba->index_bi_tau,_TRUE_,index_bi,1);
+
+  /* -> log energy density in CDM */
+  class_define_index(pba->index_bi_lnrho_cdm,pba->has_cdm,index_bi,1);
 
   /* -> energy density in DCDM */
   class_define_index(pba->index_bi_rho_dcdm,pba->has_dcdm,index_bi,1);
@@ -2210,6 +2213,10 @@ int background_initial_conditions(
     /** - We must add the relativistic contribution from NCDM species */
     rho_rad += rho_ncdm_rel_tot;
   }
+  if (pba->has_cdm == _TRUE_) {
+    pvecback_integration[pba->index_bi_lnrho_cdm] =
+      log(pba->Omega0_cdm*pow(pba->H0,2)*pow(a,-3));
+  }
   if (pba->has_dcdm == _TRUE_) {
     /* Remember that the critical density today in CLASS conventions is H0^2 */
     pvecback_integration[pba->index_bi_rho_dcdm] =
@@ -2638,6 +2645,10 @@ int background_derivs(
 
   dy[pba->index_bi_D] = y[pba->index_bi_D_prime]/a/H;
   dy[pba->index_bi_D_prime] = -y[pba->index_bi_D_prime] + 1.5*a*rho_M*y[pba->index_bi_D]/H;
+
+  if (pba->has_cdm == _TRUE_) {
+    dy[pba->index_bi_lnrho_cdm] = -3.;
+  }
 
   if (pba->has_dcdm == _TRUE_) {
     /** - compute dcdm density \f$ d\rho/dloga = -3 \rho - \Gamma/H \rho \f$*/

--- a/source/perturbations.c
+++ b/source/perturbations.c
@@ -5285,7 +5285,7 @@ int perturbations_initial_conditions(struct precision * ppr,
   double delta_dr=0;
   double q,epsilon,k2;
   int index_q,n_ncdm,idx;
-  double rho_r,rho_m,rho_nu,rho_m_over_rho_r, rho_cdm =0.;
+  double rho_r,rho_m,rho_nu,rho_m_over_rho_r, rho_cdm =0., rho_cdm_bg=0.;
   double fracnu,fracg,fracb,fraccdm = 0.,fracidm = 0.;
   double om;
   double ktau_two,ktau_three;
@@ -5320,7 +5320,9 @@ int perturbations_initial_conditions(struct precision * ppr,
   rho_nu = 0.;
 
   if (pba->has_cdm == _TRUE_) {
-    rho_m += ppw->pvecback[pba->index_bg_rho_cdm];
+    rho_cdm_bg = ppw->pvecback[pba->index_bg_rho_cdm];
+    if (rho_cdm_bg < 0.) rho_cdm_bg = 0.;
+    rho_m += rho_cdm_bg;
   }
 
   if (pba->has_idm == _TRUE_) {
@@ -5376,7 +5378,7 @@ int perturbations_initial_conditions(struct precision * ppr,
 
     /* f_cdm = Omega_cdm(t_i) / Omega_m(t_i) */
     if (pba->has_cdm == _TRUE_)
-      fraccdm = ppw->pvecback[pba->index_bg_rho_cdm]/rho_m;
+      fraccdm = rho_cdm_bg/rho_m;
 
     /* f_idm = Omega_idm(t_i) / Omega_m(t_i) */
     if (pba->has_idm == _TRUE_){
@@ -5686,8 +5688,11 @@ int perturbations_initial_conditions(struct precision * ppr,
       */
 
       if (pba->has_cdm == _TRUE_) {
-        delta_cdm += ppw->pvecback[pba->index_bg_rho_cdm] * ppw->pv->y[ppw->pv->index_pt_delta_cdm];
-        rho_cdm += ppw->pvecback[pba->index_bg_rho_cdm];
+        double rho_cdm_tmp = ppw->pvecback[pba->index_bg_rho_cdm];
+        if (rho_cdm_tmp > 0.) {
+          delta_cdm += rho_cdm_tmp * ppw->pv->y[ppw->pv->index_pt_delta_cdm];
+          rho_cdm += rho_cdm_tmp;
+        }
       }
       if (pba->has_idm == _TRUE_) {
         delta_cdm += ppw->pvecback[pba->index_bg_rho_idm] * ppw->pv->y[ppw->pv->index_pt_delta_idm];


### PR DESCRIPTION
## Summary
- evolve CDM background density in logarithmic form to enforce positivity
- initialize and restore CDM density consistently in background functions
- guard perturbation set-up against negative CDM densities

## Testing
- `make test_background`
- `make test_perturbations`


------
https://chatgpt.com/codex/tasks/task_e_68af107957008333804d56136db2f283