### PR TITLE
Damp Gibbons-Hawking wear with configurable late-time switch

### DIFF
--- a/source/background.c
+++ b/source/background.c
@@ -2663,9 +2663,7 @@ int background_derivs(
 
   if (pba->use_time_wear_GH == _TRUE_) {
     double S = pba->alpha_GH * H / pba->H0;
-    if (pba->time_wear_GH_a_t > 0.) {
-      S /= 1.+pow(pba->time_wear_GH_a_t/a, pba->time_wear_GH_m);
-    }
+    S /= 1.+pow(pba->time_wear_GH_a_t/a, pba->time_wear_GH_m);
     dy[pba->index_bi_rho_cdm] = -(3.+S)*y[pba->index_bi_rho_cdm];
   }
 

--- a/source/input.c
+++ b/source/input.c
@@ -5923,8 +5923,8 @@ int input_default_params(struct background *pba,
   /* Gibbons-Hawking time wear defaults */
   pba->use_time_wear_GH = _FALSE_;
   pba->alpha_GH = 0.;
-  pba->time_wear_GH_a_t = 0.;
-  pba->time_wear_GH_m = 1.;
+  pba->time_wear_GH_a_t = 0.3;
+  pba->time_wear_GH_m = 6.;
   /** 9.a.2) Equation of state */
   pba->fluid_equation_of_state = CLP;
   pba->w0_fld = -1.;

--- a/source/perturbations.c
+++ b/source/perturbations.c
@@ -9225,9 +9225,7 @@ int perturbations_derivs(double tau,
         double a = ppw->pvecback[pba->index_bg_a];
         double H = ppw->pvecback[pba->index_bg_H];
         S_cdm = pba->alpha_GH * H / pba->H0;
-        if (pba->time_wear_GH_a_t > 0.) {
-          S_cdm /= 1.+pow(pba->time_wear_GH_a_t/a, pba->time_wear_GH_m);
-        }
+        S_cdm /= 1.+pow(pba->time_wear_GH_a_t/a, pba->time_wear_GH_m);
         S_cdm *= a*H;
       }
 


### PR DESCRIPTION
## Summary
- Always suppress Gibbons-Hawking wear with 1/[1+(a_t/a)^m] factor
- Default late-time switch parameters to a_t=0.3 and m=6, overridable from .ini
- Apply switch consistently in background and perturbation equations

## Testing
- `make test_background`
- `./test_background`
- `make test_perturbations`
- `./test_perturbations`


------
https://chatgpt.com/codex/tasks/task_e_68af17724cec83339421e822996b0e72