### PR TITLE
Add ROFT-add dark energy model

### DIFF
--- a/default.ini
+++ b/default.ini
@@ -116,6 +116,10 @@ N_ncdm =                          # Massive neutrino species
 #Omega_EDE = 0.
 #cs2_fld = 1
 
+#ROFT additive model
+#roft_model = none   # options: none, add
+#alpha_roft = 0.0
+
 # ----------------------------
 # ----> Thermodynamics/Heating parameters:
 # ----------------------------

--- a/explanatory.ini
+++ b/explanatory.ini
@@ -658,6 +658,10 @@ fluid_equation_of_state = CLP
 #Omega_EDE = 0.
 #cs2_fld = 1
 
+# 8.a.2.3) ROFT additive model
+#roft_model = none        # options: none, add
+#alpha_roft = 0.0         # ensure R(z)=1+alpha*ln(1+z) > 0 up to z_max
+
 # 8.b) If Omega scalar field is different from 0
 
 # 8.b.1) Scalar field (scf) potential parameters and initial conditions

--- a/include/background.h
+++ b/include/background.h
@@ -14,6 +14,9 @@
 
 enum equation_of_state {CLP,EDE};
 
+/** list of possible ROFT dark energy models */
+enum roft_model {roft_none,roft_add};
+
 
 /** list of possible parametrizations of the varying fundamental constants */
 
@@ -111,6 +114,9 @@ struct background
   double wa_fld;   /**< \f$ wa_{DE} \f$: fluid equation of state parameter derivative */
   double cs2_fld;  /**< \f$ c^2_{s~DE} \f$: sound speed of the fluid in the frame comoving with the fluid (so, this is
                       not [delta p/delta rho] in the synchronous or newtonian gauge!) */
+  short has_roft;       /**< presence of ROFT-add dark energy? */
+  enum roft_model roft_model_id; /**< identifier for ROFT model */
+  double alpha_roft;    /**< ROFT parameter */
   double Omega_EDE;        /**< \f$ wa_{DE} \f$: Early Dark Energy density parameter */
   double * scf_parameters; /**< list of parameters describing the scalar field potential */
   short attractor_ic_scf;  /**< whether the scalar field has attractor initial conditions */

--- a/include/precisions.h
+++ b/include/precisions.h
@@ -10,6 +10,12 @@
  */
 class_precision_parameter(a_ini_over_a_today_default,double,1.e-14)
 /**
+ * Maximum redshift used when checking positivity of the ROFT-add
+ * parametrisation. Ensures that R(z)=1+alpha_roft*ln(1+z) stays
+ * positive up to this redshift (or a larger z requested elsewhere).
+ */
+class_precision_parameter(roft_guard_zmax,double,3000.)
+/**
  * Number of background integration steps that are stored in the output vector
  */
 class_precision_parameter(background_Nloga,int,40000)

--- a/source/background.c
+++ b/source/background.c
@@ -674,6 +674,15 @@ int background_w_fld(
   double d2Omega_ede_over_da2 = 0.;
   double a_eq, Omega_r, Omega_m;
 
+  /* ROFT-add model */
+  if (pba->has_roft == _TRUE_) {
+    double R = 1. - pba->alpha_roft * log(a);
+    *w_fld = -1. + pba->alpha_roft/(3.*R);
+    *dw_over_da_fld = pba->alpha_roft*pba->alpha_roft/(3.*R*R*a);
+    *integral_fld = log(R);
+    return _SUCCESS_;
+  }
+
   /** - first, define the function w(a) */
   switch (pba->fluid_equation_of_state) {
   case CLP:
@@ -2061,6 +2070,11 @@ int background_solve(
     printf(" -> age = %f Gyr\n",pba->age);
     printf(" -> conformal age = %f Mpc\n",pba->conformal_age);
     printf(" -> N_eff = %g (summed over all species that are non-relativistic at early times) \n",pba->Neff);
+    if (pba->has_roft == _TRUE_) {
+      double a_min = exp(pba->loga_table[0]);
+      printf(" -> w0 = %g\n", -1. + pba->alpha_roft/3.);
+      printf(" -> R(a=1)=1 ; R(a_min)=%g\n", 1. - pba->alpha_roft*log(a_min));
+    }
   }
 
   if (pba->background_verbose > 2) {

--- a/source/input.c
+++ b/source/input.c
@@ -3261,6 +3261,38 @@ int input_read_parameters_species(struct file_content * pfc,
     }
   }
 
+  /* ROFT model parameters */
+  class_call(parser_read_string(pfc,"roft_model",&string1,&flag1,errmsg),
+             errmsg,
+             errmsg);
+  if (flag1 == _TRUE_) {
+    if ((strstr(string1,"add") != NULL) || (strstr(string1,"ADD") != NULL)) {
+      pba->has_roft = _TRUE_;
+      pba->roft_model_id = roft_add;
+    }
+    else if ((strstr(string1,"none") != NULL) || (strstr(string1,"NONE") != NULL)) {
+      pba->has_roft = _FALSE_;
+      pba->roft_model_id = roft_none;
+    }
+    else {
+      class_stop(errmsg,"incomprehensible input '%s' for the field 'roft_model'",string1);
+    }
+  }
+  class_read_double("alpha_roft",pba->alpha_roft);
+  if (pba->has_roft == _TRUE_) {
+    double z_max = 1./ppr->a_ini_over_a_today_default - 1.;
+    if (z_max <= 0.) z_max = 3000.;
+    double alpha_min = -1./log(1.+z_max);
+    class_test(1.+pba->alpha_roft*log(1.+z_max) <= 0.,
+               errmsg,
+               "Configuration invalide: R(z) <= 0 jusqu'a z_max = %g ; alpha > alpha_min = %g requis.",
+               z_max,alpha_min);
+    pba->Omega0_fld += pba->Omega0_lambda;
+    pba->Omega0_lambda = 0.;
+    if (input_verbose > 0)
+      printf(" -> ROFT-add activated (alpha = %g)\n",pba->alpha_roft);
+  }
+
   /* ** END OF BUDGET EQUATION ** */
 
   /** 8.a) If Omega fluid is different from 0 */
@@ -3280,37 +3312,43 @@ int input_read_parameters_species(struct file_content * pfc,
       }
     }
 
-    /** 8.a.2) Equation of state */
-    /* Read */
-    class_call(parser_read_string(pfc,"fluid_equation_of_state",&string1,&flag1,errmsg),
-               errmsg,
-               errmsg);
-    /* Complete set of parameters */
-    if (flag1 == _TRUE_) {
-      if ((strstr(string1,"CLP") != NULL) || (strstr(string1,"clp") != NULL)) {
-        pba->fluid_equation_of_state = CLP;
-      }
-      else if ((strstr(string1,"EDE") != NULL) || (strstr(string1,"ede") != NULL)) {
-        pba->fluid_equation_of_state = EDE;
-      }
-      else {
-        class_stop(errmsg,"incomprehensible input '%s' for the field 'fluid_equation_of_state'",string1);
-      }
+    if (pba->has_roft == _TRUE_) {
+      /* Only sound speed is needed for ROFT-add */
+      class_read_double("cs2_fld",pba->cs2_fld);
     }
+    else {
+      /** 8.a.2) Equation of state */
+      /* Read */
+      class_call(parser_read_string(pfc,"fluid_equation_of_state",&string1,&flag1,errmsg),
+                 errmsg,
+                 errmsg);
+      /* Complete set of parameters */
+      if (flag1 == _TRUE_) {
+        if ((strstr(string1,"CLP") != NULL) || (strstr(string1,"clp") != NULL)) {
+          pba->fluid_equation_of_state = CLP;
+        }
+        else if ((strstr(string1,"EDE") != NULL) || (strstr(string1,"ede") != NULL)) {
+          pba->fluid_equation_of_state = EDE;
+        }
+        else {
+          class_stop(errmsg,"incomprehensible input '%s' for the field 'fluid_equation_of_state'",string1);
+        }
+      }
 
-    if (pba->fluid_equation_of_state == CLP) {
-      /** 8.a.2.2) Equation of state of the fluid in 'CLP' case */
-      /* Read */
-      class_read_double("w0_fld",pba->w0_fld);
-      class_read_double("wa_fld",pba->wa_fld);
-      class_read_double("cs2_fld",pba->cs2_fld);
-    }
-    if (pba->fluid_equation_of_state == EDE) {
-      /** 8.a.2.3) Equation of state of the fluid in 'EDE' case */
-      /* Read */
-      class_read_double("w0_fld",pba->w0_fld);
-      class_read_double("Omega_EDE",pba->Omega_EDE);
-      class_read_double("cs2_fld",pba->cs2_fld);
+      if (pba->fluid_equation_of_state == CLP) {
+        /** 8.a.2.2) Equation of state of the fluid in 'CLP' case */
+        /* Read */
+        class_read_double("w0_fld",pba->w0_fld);
+        class_read_double("wa_fld",pba->wa_fld);
+        class_read_double("cs2_fld",pba->cs2_fld);
+      }
+      if (pba->fluid_equation_of_state == EDE) {
+        /** 8.a.2.3) Equation of state of the fluid in 'EDE' case */
+        /* Read */
+        class_read_double("w0_fld",pba->w0_fld);
+        class_read_double("Omega_EDE",pba->Omega_EDE);
+        class_read_double("cs2_fld",pba->cs2_fld);
+      }
     }
   }
 
@@ -5913,6 +5951,9 @@ int input_default_params(struct background *pba,
   pba->fluid_equation_of_state = CLP;
   pba->w0_fld = -1.;
   pba->cs2_fld = 1.;
+  pba->has_roft = _FALSE_;
+  pba->roft_model_id = roft_none;
+  pba->alpha_roft = 0.;
   /** 9.a.2.1) 'CLP' case */
   pba->wa_fld = 0.;
   /** 9.a.2.2) 'EDE' case */

--- a/source/input.c
+++ b/source/input.c
@@ -3280,17 +3280,18 @@ int input_read_parameters_species(struct file_content * pfc,
   }
   class_read_double("alpha_roft",pba->alpha_roft);
   if (pba->has_roft == _TRUE_) {
-    double z_max = 1./ppr->a_ini_over_a_today_default - 1.;
-    if (z_max <= 0.) z_max = 3000.;
-    double alpha_min = -1./log(1.+z_max);
-    class_test(1.+pba->alpha_roft*log(1.+z_max) <= 0.,
-               errmsg,
-               "Configuration invalide: R(z) <= 0 jusqu'a z_max = %g ; alpha > alpha_min = %g requis.",
-               z_max,alpha_min);
-    pba->Omega0_fld += pba->Omega0_lambda;
-    pba->Omega0_lambda = 0.;
-    if (input_verbose > 0)
-      printf(" -> ROFT-add activated (alpha = %g)\n",pba->alpha_roft);
+    if (pba->alpha_roft == 0.) {
+      pba->has_roft = _FALSE_;
+      pba->roft_model_id = roft_none;
+      if (input_verbose > 0)
+        printf(" -> ROFT-add deactivated (alpha = 0)\n");
+    }
+    else {
+      pba->Omega0_fld += pba->Omega0_lambda;
+      pba->Omega0_lambda = 0.;
+      if (input_verbose > 0)
+        printf(" -> ROFT-add activated (alpha = %g)\n",pba->alpha_roft);
+    }
   }
 
   /* ** END OF BUDGET EQUATION ** */
@@ -4762,6 +4763,8 @@ int input_read_parameters_spectra(struct file_content * pfc,
   int i;
   double z_max=0.;
   int bin;
+  int input_verbose = 0;
+  class_read_int("input_verbose",input_verbose);
 
   /** 1) Maximum l for CLs */
   /* Read */
@@ -5058,6 +5061,17 @@ int input_read_parameters_spectra(struct file_content * pfc,
       }
       /* Now we have checked all contributions that could change z_max_pk */
     }
+  }
+
+  if (pba->has_roft == _TRUE_) {
+    double z_guard = MAX(ppr->roft_guard_zmax,ppt->z_max_pk);
+    double alpha_min = -1./log(1.+z_guard);
+    class_test(1.+pba->alpha_roft*log(1.+z_guard) <= 0.,
+               errmsg,
+               "Configuration invalide: R(z) <= 0 jusqu'a z_guard = %g ; alpha > alpha_min = %g requis.",
+               z_guard,alpha_min);
+    if (input_verbose > 0)
+      printf(" -> ROFT guard: z_guard = %g, alpha_min = %g\n",z_guard,alpha_min);
   }
 
   return _SUCCESS_;


### PR DESCRIPTION
## Summary
- introduce ROFT-add model parameters and bookkeeping
- implement ROFT background and perturbation handling with positivity checks
- document new ROFT-add inputs in default and explanatory configs

## Testing
- `make -j4`
- `make test_background`
- `./test_background`


------
https://chatgpt.com/codex/tasks/task_e_68c440bfb34c8333afa58874b1fbc629