### PR TITLE
Clarify ROFT constraint handling

### DIFF
--- a/default.ini
+++ b/default.ini
@@ -119,7 +119,7 @@ N_ncdm =                          # Massive neutrino species
 #ROFT additive model
 #roft_model = none   # options: none, add
 #alpha_roft = 0.0
-#roft_guard_zmax = 3000.  # enforce R(z)>0 up to this redshift
+#roft_guard_zmax = 3000.  # enforce R(z)>0 up to this redshift (default=max(z_max_pk,3000))
 
 # ----------------------------
 # ----> Thermodynamics/Heating parameters:

--- a/default.ini
+++ b/default.ini
@@ -119,6 +119,7 @@ N_ncdm =                          # Massive neutrino species
 #ROFT additive model
 #roft_model = none   # options: none, add
 #alpha_roft = 0.0
+#roft_guard_zmax = 3000.  # enforce R(z)>0 up to this redshift
 
 # ----------------------------
 # ----> Thermodynamics/Heating parameters:

--- a/default.ini
+++ b/default.ini
@@ -119,7 +119,7 @@ N_ncdm =                          # Massive neutrino species
 #ROFT additive model
 #roft_model = none   # options: none, add
 #alpha_roft = 0.0
-#roft_guard_zmax = 3000.  # enforce R(z)>0 up to this redshift (default=max(z_max_pk,3000))
+#roft_guard_zmax = 3000.  # enforce R(z)>0 up to this redshift (default=3000)
 
 # ----------------------------
 # ----> Thermodynamics/Heating parameters:

--- a/explanatory.ini
+++ b/explanatory.ini
@@ -661,7 +661,7 @@ fluid_equation_of_state = CLP
 # 8.a.2.3) ROFT additive model
 #roft_model = none        # options: none, add
 #alpha_roft = 0.0         # ensure R(z)=1+alpha*ln(1+z) > 0 up to roft_guard_zmax
-#roft_guard_zmax = 3000.  # optional guard redshift for R(z); default=max(z_max_pk,3000)
+#roft_guard_zmax = 3000.  # optional guard redshift for R(z); default=3000
 
 # 8.b) If Omega scalar field is different from 0
 

--- a/explanatory.ini
+++ b/explanatory.ini
@@ -660,7 +660,8 @@ fluid_equation_of_state = CLP
 
 # 8.a.2.3) ROFT additive model
 #roft_model = none        # options: none, add
-#alpha_roft = 0.0         # ensure R(z)=1+alpha*ln(1+z) > 0 up to z_max
+#alpha_roft = 0.0         # ensure R(z)=1+alpha*ln(1+z) > 0 up to roft_guard_zmax
+#roft_guard_zmax = 3000.  # optional guard redshift for R(z)
 
 # 8.b) If Omega scalar field is different from 0
 

--- a/explanatory.ini
+++ b/explanatory.ini
@@ -661,7 +661,7 @@ fluid_equation_of_state = CLP
 # 8.a.2.3) ROFT additive model
 #roft_model = none        # options: none, add
 #alpha_roft = 0.0         # ensure R(z)=1+alpha*ln(1+z) > 0 up to roft_guard_zmax
-#roft_guard_zmax = 3000.  # optional guard redshift for R(z)
+#roft_guard_zmax = 3000.  # optional guard redshift for R(z); default=max(z_max_pk,3000)
 
 # 8.b) If Omega scalar field is different from 0
 

--- a/include/background.h
+++ b/include/background.h
@@ -116,7 +116,7 @@ struct background
                       not [delta p/delta rho] in the synchronous or newtonian gauge!) */
   short has_roft;       /**< presence of ROFT-add dark energy? */
   enum roft_model roft_model_id; /**< identifier for ROFT model */
-  double alpha_roft;    /**< ROFT parameter */
+  double alpha_roft;    /**< ROFT parameter (requires \f$R(z)=1+\alpha_{\mathrm{roft}}\ln(1+z)>0\f$ up to a guard redshift) */
   double Omega_EDE;        /**< \f$ wa_{DE} \f$: Early Dark Energy density parameter */
   double * scf_parameters; /**< list of parameters describing the scalar field potential */
   short attractor_ic_scf;  /**< whether the scalar field has attractor initial conditions */

--- a/include/background.h
+++ b/include/background.h
@@ -117,6 +117,7 @@ struct background
   short has_roft;       /**< presence of ROFT-add dark energy? */
   enum roft_model roft_model_id; /**< identifier for ROFT model */
   double alpha_roft;    /**< ROFT parameter (requires \f$R(z)=1+\alpha_{\mathrm{roft}}\ln(1+z)>0\f$ up to a guard redshift) */
+  double roft_guard_zmax; /**< optional guard redshift enforcing \f$R(z)>0\f$ */
   double Omega_EDE;        /**< \f$ wa_{DE} \f$: Early Dark Energy density parameter */
   double * scf_parameters; /**< list of parameters describing the scalar field potential */
   short attractor_ic_scf;  /**< whether the scalar field has attractor initial conditions */

--- a/include/background.h
+++ b/include/background.h
@@ -117,7 +117,7 @@ struct background
   short has_roft;       /**< presence of ROFT-add dark energy? */
   enum roft_model roft_model_id; /**< identifier for ROFT model */
   double alpha_roft;    /**< ROFT parameter (requires \f$R(z)=1+\alpha_{\mathrm{roft}}\ln(1+z)>0\f$ up to a guard redshift) */
-  double roft_guard_zmax; /**< optional guard redshift enforcing \f$R(z)>0\f$ */
+  double roft_guard_zmax; /**< guard redshift enforcing \f$R(z)>0\f$ (default 3000) */
   double Omega_EDE;        /**< \f$ wa_{DE} \f$: Early Dark Energy density parameter */
   double * scf_parameters; /**< list of parameters describing the scalar field potential */
   short attractor_ic_scf;  /**< whether the scalar field has attractor initial conditions */

--- a/source/input.c
+++ b/source/input.c
@@ -3280,13 +3280,17 @@ int input_read_parameters_species(struct file_content * pfc,
   }
   class_read_double("alpha_roft",pba->alpha_roft);
   if (pba->has_roft == _TRUE_) {
-    double z_max = 1./ppr->a_ini_over_a_today_default - 1.;
-    if (z_max <= 0.) z_max = 3000.;
-    double alpha_min = -1./log(1.+z_max);
-    class_test(1.+pba->alpha_roft*log(1.+z_max) <= 0.,
+    class_call(parser_read_double(pfc,"roft_guard_zmax",&param1,&flag1,errmsg),
                errmsg,
-               "Configuration invalide: R(z) <= 0 jusqu'a z_max = %g ; alpha > alpha_min = %g requis.",
-               z_max,alpha_min);
+               errmsg);
+    double z_guard = flag1 == _TRUE_ ? param1 : 3000.;
+    double alpha_min = -1./log(1.+z_guard);
+    if (input_verbose > 0)
+      printf("ROFT guard: z_guard=%g, alpha_min=%g\n",z_guard,alpha_min);
+    class_test(1.+pba->alpha_roft*log(1.+z_guard) <= 0.,
+               errmsg,
+               "Invalid configuration: R(z)=1+alpha_roft*log(1+z) <= 0 up to z_guard = %g; require alpha_roft > alpha_min = %g.",
+               z_guard,alpha_min);
     pba->Omega0_fld += pba->Omega0_lambda;
     pba->Omega0_lambda = 0.;
     if (input_verbose > 0)

--- a/source/input.c
+++ b/source/input.c
@@ -1731,6 +1731,20 @@ int input_read_parameters(struct file_content * pfc,
              errmsg,
              errmsg);
 
+  if (pba->has_roft == _TRUE_) {
+    if (pba->roft_guard_zmax <= 0.) {
+      pba->roft_guard_zmax = (ppt->z_max_pk > 0.) ? MAX(ppt->z_max_pk,3000.) : 3000.;
+    }
+    double z_guard = pba->roft_guard_zmax;
+    double alpha_min = -1./log(1.+z_guard);
+    if (input_verbose > 0)
+      printf("ROFT guard: z_guard=%g, alpha_min=%g\n",z_guard,alpha_min);
+    class_test(1.+pba->alpha_roft*log(1.+z_guard) <= 0.,
+               errmsg,
+               "Invalid configuration: R(z)=1+alpha_roft*log(1+z) <= 0 up to z_guard = %g; require alpha_roft > alpha_min = %g.",
+               z_guard,alpha_min);
+  }
+
   return _SUCCESS_;
 
 }
@@ -3283,14 +3297,7 @@ int input_read_parameters_species(struct file_content * pfc,
     class_call(parser_read_double(pfc,"roft_guard_zmax",&param1,&flag1,errmsg),
                errmsg,
                errmsg);
-    double z_guard = flag1 == _TRUE_ ? param1 : 3000.;
-    double alpha_min = -1./log(1.+z_guard);
-    if (input_verbose > 0)
-      printf("ROFT guard: z_guard=%g, alpha_min=%g\n",z_guard,alpha_min);
-    class_test(1.+pba->alpha_roft*log(1.+z_guard) <= 0.,
-               errmsg,
-               "Invalid configuration: R(z)=1+alpha_roft*log(1+z) <= 0 up to z_guard = %g; require alpha_roft > alpha_min = %g.",
-               z_guard,alpha_min);
+    pba->roft_guard_zmax = flag1 == _TRUE_ ? param1 : -1.;
     pba->Omega0_fld += pba->Omega0_lambda;
     pba->Omega0_lambda = 0.;
     if (input_verbose > 0)
@@ -5958,6 +5965,7 @@ int input_default_params(struct background *pba,
   pba->has_roft = _FALSE_;
   pba->roft_model_id = roft_none;
   pba->alpha_roft = 0.;
+  pba->roft_guard_zmax = -1.;
   /** 9.a.2.1) 'CLP' case */
   pba->wa_fld = 0.;
   /** 9.a.2.2) 'EDE' case */

--- a/source/input.c
+++ b/source/input.c
@@ -1732,9 +1732,6 @@ int input_read_parameters(struct file_content * pfc,
              errmsg);
 
   if (pba->has_roft == _TRUE_) {
-    if (pba->roft_guard_zmax <= 0.) {
-      pba->roft_guard_zmax = (ppt->z_max_pk > 0.) ? MAX(ppt->z_max_pk,3000.) : 3000.;
-    }
     double z_guard = pba->roft_guard_zmax;
     double alpha_min = -1./log(1.+z_guard);
     if (input_verbose > 0)
@@ -3297,7 +3294,13 @@ int input_read_parameters_species(struct file_content * pfc,
     class_call(parser_read_double(pfc,"roft_guard_zmax",&param1,&flag1,errmsg),
                errmsg,
                errmsg);
-    pba->roft_guard_zmax = flag1 == _TRUE_ ? param1 : -1.;
+    if (flag1 == _TRUE_) {
+      class_test(param1 <= 0.,errmsg,"incomprehensible or non-positive input for 'roft_guard_zmax'" );
+      pba->roft_guard_zmax = param1;
+    }
+    else {
+      pba->roft_guard_zmax = 3000.;
+    }
     pba->Omega0_fld += pba->Omega0_lambda;
     pba->Omega0_lambda = 0.;
     if (input_verbose > 0)
@@ -5965,7 +5968,7 @@ int input_default_params(struct background *pba,
   pba->has_roft = _FALSE_;
   pba->roft_model_id = roft_none;
   pba->alpha_roft = 0.;
-  pba->roft_guard_zmax = -1.;
+  pba->roft_guard_zmax = 3000.;
   /** 9.a.2.1) 'CLP' case */
   pba->wa_fld = 0.;
   /** 9.a.2.2) 'EDE' case */


### PR DESCRIPTION
## Summary
- Enforce ROFT positivity using a configurable `roft_guard_zmax` (default 3000) and detailed logging
- Document ROFT guard parameter in background header and example configuration files

## Testing
- `make test_background`
- `./test_background | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68c4594bfc60833397a0bad501eda9ec