### PR TITLE
Improve ROFT guard and input logging

### DIFF
--- a/default.ini
+++ b/default.ini
@@ -119,6 +119,7 @@ N_ncdm =                          # Massive neutrino species
 #ROFT additive model
 #roft_model = none   # options: none, add
 #alpha_roft = 0.0
+#roft_guard_zmax = 3000.   # max redshift to enforce R(z)>0
 
 # ----------------------------
 # ----> Thermodynamics/Heating parameters:

--- a/explanatory.ini
+++ b/explanatory.ini
@@ -661,6 +661,7 @@ fluid_equation_of_state = CLP
 # 8.a.2.3) ROFT additive model
 #roft_model = none        # options: none, add
 #alpha_roft = 0.0         # ensure R(z)=1+alpha*ln(1+z) > 0 up to z_max
+#roft_guard_zmax = 3000.  # enforce R(z)>0 up to this redshift
 
 # 8.b) If Omega scalar field is different from 0
 

--- a/source/input.c
+++ b/source/input.c
@@ -399,6 +399,7 @@ int input_read_from_file(struct file_content * pfc,
   /** - Define local variables */
   int input_verbose = 0;
   int has_shooting;
+  int i;
 
   /** Set default values
       Before getting into the assignment of parameters and the shooting, we want
@@ -443,6 +444,14 @@ int input_read_from_file(struct file_content * pfc,
                               errmsg),
              errmsg,
              errmsg);
+
+  if (input_verbose > 0) {
+    printf(" -> CLASS extra_args final:");
+    for (i=0; i<pfc->size; i++) {
+      printf(" %s=%s", pfc->name[i], pfc->value[i]);
+    }
+    printf("\n");
+  }
 
   if (pfo->has_pk_eq == _TRUE_) {
 
@@ -5071,7 +5080,7 @@ int input_read_parameters_spectra(struct file_content * pfc,
                "Configuration invalide: R(z) <= 0 jusqu'a z_guard = %g ; alpha > alpha_min = %g requis.",
                z_guard,alpha_min);
     if (input_verbose > 0)
-      printf(" -> ROFT guard: z_guard = %g, alpha_min = %g\n",z_guard,alpha_min);
+      printf(" -> ROFT guard: z_guard = %g -> alpha_min = %g\n",z_guard,alpha_min);
   }
 
   return _SUCCESS_;


### PR DESCRIPTION
## Summary
- log final CLASS extra_args when input_verbose>0
- report ROFT guard using physical z and document roft_guard_zmax

## Testing
- `make test_background`
- `./test_background`

------
https://chatgpt.com/codex/tasks/task_e_68c48ed33e788333a5f8641e07e3eb52