### PR TITLE
Add ROFT dark energy model

### DIFF
--- a/README_ROFT.md
+++ b/README_ROFT.md
@@ -1,0 +1,39 @@
+# ROFT extension for CLASS
+
+This branch adds a phenomenological late--time dark energy model where the fluid
+obeys
+\(w(a) = -1 + \alpha / [3 R(a)]\) with \(R(a) = 1 - \alpha \ln a\).
+The implementation introduces two new input parameters:
+
+- `alpha_roft` &mdash; controls the deviation from $\Lambda$CDM. Setting
+  `alpha_roft = 0` exactly reproduces $\Lambda$CDM.
+- `roft_model` &mdash; selects the variant of the model. At the moment only the
+  `add` model is implemented. A future `lapse` model is blocked by a safety
+  check.
+
+## Example run
+
+An example configuration is provided in `test_roft.ini`:
+
+```
+./class test_roft.ini
+```
+
+The file enables background and perturbation outputs for `alpha_roft = 0.1`.
+To compare with the $\Lambda$CDM limit set `alpha_roft = 0` in the same file.
+
+## Regression check
+
+A small script `scripts/test_roft_regression.py` runs CLASS twice and checks that
+`alpha_roft = 0` matches a pure $\Lambda$CDM run within $10^{-4}$ for the
+background expansion and CMB spectra:
+
+```
+python scripts/test_roft_regression.py
+```
+
+## Notes
+
+The code guards against negative values of $R(a)$; if this happens CLASS will
+stop with an error message. Only the `add` model affects the background and
+perturbations. The `lapse` option is reserved for future work.

--- a/README_ROFT.md
+++ b/README_ROFT.md
@@ -1,8 +1,7 @@
 # ROFT extension for CLASS
 
 This branch adds a phenomenological late--time dark energy model where the fluid
-obeys
-\(w(a) = -1 + \alpha / [3 R(a)]\) with \(R(a) = 1 - \alpha \ln a\).
+obeys \(w(a) = -1 + \alpha / [3 R(a)]\) with \(R(a) = 1 - \alpha \ln a\).
 The implementation introduces two new input parameters:
 
 - `alpha_roft` &mdash; controls the deviation from $\Lambda$CDM. Setting
@@ -10,6 +9,11 @@ The implementation introduces two new input parameters:
 - `roft_model` &mdash; selects the variant of the model. At the moment only the
   `add` model is implemented. A future `lapse` model is blocked by a safety
   check.
+
+Choosing `fluid_equation_of_state = ROFT` always promotes the cosmological
+constant to a dynamical fluid. When `alpha_roft = 0` this branch remains
+numerically identical to $\Lambda$CDM but runs through the `fld` code path for
+consistency.
 
 ## Example run
 

--- a/explanatory.ini
+++ b/explanatory.ini
@@ -632,7 +632,8 @@ c_gamma_over_c_fld = 0.4
 # 8.a.2) Choose your equation of state between different models,
 #         - 'CLP' for p/rho = w0_fld + wa_fld (1-a/a0)
 #           (Chevalier-Linder-Polarski),
-#         - 'EDE' for early Dark Energy
+#         - 'EDE' for early Dark Energy,
+#         - 'ROFT' for Running Origin of Field Time (implemented models listed below)
 #      (default:'fluid_equation_of_state' set to 'CLP')
 fluid_equation_of_state = CLP
 
@@ -657,6 +658,10 @@ fluid_equation_of_state = CLP
 #w0_fld = -0.9
 #Omega_EDE = 0.
 #cs2_fld = 1
+
+# 8.a.2.3) ROFT extension parameters when 'ROFT' is selected
+#alpha_roft = 0.0   # Horloge tardive, alpha=0 => ΛCDM
+#roft_model = add   # add|lapse (seul add est implémenté)
 
 # 8.b) If Omega scalar field is different from 0
 

--- a/include/background.h
+++ b/include/background.h
@@ -12,7 +12,11 @@
 
 /** list of possible parametrisations of the DE equation of state */
 
-enum equation_of_state {CLP,EDE};
+enum equation_of_state {CLP,EDE,ROFT};
+
+/** list of ROFT model implementations */
+
+enum roft_type {roft_add,roft_lapse};
 
 
 /** list of possible parametrizations of the varying fundamental constants */
@@ -103,6 +107,8 @@ struct background
   double Omega0_lambda;    /**< \f$ \Omega_{0_\Lambda} \f$: cosmological constant */
   double Omega0_fld;       /**< \f$ \Omega_{0 de} \f$: fluid */
   double Omega0_scf;       /**< \f$ \Omega_{0 scf} \f$: scalar field */
+  double alpha_roft;       /**< late-time clock parameter alpha */
+  enum roft_type roft_model; /**< choice of ROFT model */
   short use_ppf; /**< flag switching on PPF perturbation equations instead of true fluid equations for perturbations. It could have been defined inside
                     perturbation structure, but we leave it here in such way to have all fld parameters grouped. */
   double c_gamma_over_c_fld; /**< ppf parameter defined in eq. (16) of 0808.3125 [astro-ph] */

--- a/scripts/test_roft_regression.py
+++ b/scripts/test_roft_regression.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Check that alpha_roft = 0 reproduces LCDM."""
+import numpy as np
+import subprocess
+import tempfile
+import os
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.join(HERE, "..")
+CLASS = os.path.join(ROOT, "class")
+DEFAULT = os.path.join(ROOT, "default.ini")
+
+def run(extra, root):
+    cfg = open(DEFAULT).read().replace("write_background = no", "write_background = yes")
+    cfg += f"root = {root}\n"
+    cfg += extra
+    with tempfile.NamedTemporaryFile('w', suffix='.ini', delete=False) as f:
+        f.write(cfg)
+        name = f.name
+    subprocess.run([CLASS, name], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    os.remove(name)
+    return f"{root}00_background.dat", f"{root}00_cl.dat"
+
+def relmax(a, b):
+    return np.max(np.abs(a - b) / np.where(a != 0, a, 1))
+
+def main():
+    lcdm_bg, lcdm_cl = run("", os.path.join(ROOT, "output/reg_lcdm_"))
+    roft_bg, roft_cl = run("fluid_equation_of_state = ROFT\nalpha_roft = 0.\nroft_model = add\n", os.path.join(ROOT, "output/reg_roft0_"))
+    bg1 = np.loadtxt(lcdm_bg)
+    bg2 = np.loadtxt(roft_bg)
+    cl1 = np.loadtxt(lcdm_cl)
+    cl2 = np.loadtxt(roft_cl)
+    if relmax(bg1[:,3], bg2[:,3]) > 1e-4:
+        raise SystemExit("H(z) mismatch")
+    if relmax(bg1[:,5], bg2[:,5]) > 1e-4:
+        raise SystemExit("distance mismatch")
+    if relmax(cl1[:,1], cl2[:,1]) > 1e-4:
+        raise SystemExit("C_l mismatch")
+    print("ROFT regression passed")
+
+if __name__ == "__main__":
+    main()

--- a/source/background.c
+++ b/source/background.c
@@ -673,6 +673,7 @@ int background_w_fld(
   double dOmega_ede_over_da = 0.;
   double d2Omega_ede_over_da2 = 0.;
   double a_eq, Omega_r, Omega_m;
+  double R;
 
   /** - first, define the function w(a) */
   switch (pba->fluid_equation_of_state) {
@@ -702,6 +703,11 @@ int background_w_fld(
     // w_ede(a) taken from eq. (11) in 1706.00730
     *w_fld = - dOmega_ede_over_da*a/Omega_ede/3./(1.-Omega_ede)+a_eq/3./(a+a_eq);
     break;
+  case ROFT:
+    R = 1. - pba->alpha_roft*log(a);
+    class_test(R <= 0.,pba->error_message,"ROFT R(a) becomes negative");
+    *w_fld = -1. + pba->alpha_roft/(3.*R);
+    break;
   }
 
 
@@ -721,6 +727,11 @@ int background_w_fld(
       + dOmega_ede_over_da*dOmega_ede_over_da*a/3./(1.-Omega_ede)/(1.-Omega_ede)/Omega_ede
       + a_eq/3./(a+a_eq)/(a+a_eq);
     break;
+  case ROFT:
+    R = 1. - pba->alpha_roft*log(a);
+    class_test(R <= 0.,pba->error_message,"ROFT R(a) becomes negative");
+    *dw_over_da_fld = pba->alpha_roft*pba->alpha_roft/(3.*R*R)/a;
+    break;
   }
 
   /** - finally, give the analytic solution of the following integral:
@@ -739,6 +750,11 @@ int background_w_fld(
     break;
   case EDE:
     class_stop(pba->error_message,"EDE implementation not finished: to finish it, read the comments in background.c just before this line\n");
+    break;
+  case ROFT:
+    R = 1. - pba->alpha_roft*log(a);
+    class_test(R <= 0.,pba->error_message,"ROFT R(a) becomes negative");
+    *integral_fld = log(R);
     break;
   }
 

--- a/source/input.c
+++ b/source/input.c
@@ -3286,6 +3286,18 @@ int input_read_parameters_species(struct file_content * pfc,
                "alpha_roft leads to negative R(z) at z=%g",zmax);
   }
 
+  /* Allow specifying ROFT equation of state even when Omega0_fld = 0 */
+  if (pba->Omega0_fld == 0.) {
+    class_call(parser_read_string(pfc,"fluid_equation_of_state",&string1,&flag1,errmsg),
+               errmsg,
+               errmsg);
+    if (flag1 == _TRUE_) {
+      if ((strstr(string1,"ROFT") != NULL) || (strstr(string1,"roft") != NULL)) {
+        pba->fluid_equation_of_state = ROFT;
+      }
+    }
+  }
+
   /** 8.a) If Omega fluid is different from 0 */
   if (pba->Omega0_fld != 0.) {
     /** 8.a.1) PPF approximation */
@@ -3338,7 +3350,7 @@ int input_read_parameters_species(struct file_content * pfc,
   }
 
   /* Promote Lambda to fluid for ROFT */
-  if (pba->alpha_roft != 0.) {
+  if ((pba->alpha_roft != 0.) || (pba->fluid_equation_of_state == ROFT)) {
     pba->Omega0_fld += pba->Omega0_lambda;
     pba->Omega0_lambda = 0.;
     pba->fluid_equation_of_state = ROFT;

--- a/source/input.c
+++ b/source/input.c
@@ -3263,6 +3263,29 @@ int input_read_parameters_species(struct file_content * pfc,
 
   /* ** END OF BUDGET EQUATION ** */
 
+  /* ROFT parameters */
+  class_read_double("alpha_roft",pba->alpha_roft);
+  class_call(parser_read_string(pfc,"roft_model",&string1,&flag1,errmsg),
+             errmsg,errmsg);
+  if (flag1 == _TRUE_) {
+    if ((strstr(string1,"lapse") != NULL) || (strstr(string1,"LAPSE") != NULL)) {
+      pba->roft_model = roft_lapse;
+    }
+    else {
+      pba->roft_model = roft_add;
+    }
+  }
+  class_test(pba->roft_model == roft_lapse,
+             errmsg,
+             "ROFT lapse model not implemented yet");
+
+  if (pba->alpha_roft != 0.) {
+    double zmax = 1.e4;
+    class_test(1.+pba->alpha_roft*log(1.+zmax) <= 0.,
+               errmsg,
+               "alpha_roft leads to negative R(z) at z=%g",zmax);
+  }
+
   /** 8.a) If Omega fluid is different from 0 */
   if (pba->Omega0_fld != 0.) {
     /** 8.a.1) PPF approximation */
@@ -3312,6 +3335,14 @@ int input_read_parameters_species(struct file_content * pfc,
       class_read_double("Omega_EDE",pba->Omega_EDE);
       class_read_double("cs2_fld",pba->cs2_fld);
     }
+  }
+
+  /* Promote Lambda to fluid for ROFT */
+  if (pba->alpha_roft != 0.) {
+    pba->Omega0_fld += pba->Omega0_lambda;
+    pba->Omega0_lambda = 0.;
+    pba->fluid_equation_of_state = ROFT;
+    pba->w0_fld = -1. + pba->alpha_roft/3.;
   }
 
   /** 8.b) If Omega scalar field (SCF) is different from 0 */
@@ -5905,6 +5936,8 @@ int input_default_params(struct background *pba,
   pba->Omega0_fld = 0.;
   pba->Omega0_scf = 0.;
   pba->Omega0_lambda = 1.-pba->Omega0_k-pba->Omega0_g-pba->Omega0_ur-pba->Omega0_b-pba->Omega0_cdm-pba->Omega0_ncdm_tot-pba->Omega0_dcdmdr - pba->Omega0_idr -pba->Omega0_idm;
+  pba->alpha_roft = 0.;
+  pba->roft_model = roft_add;
   /** 8.a) Omega fluid */
   /** 8.a.1) PPF approximation */
   pba->use_ppf = _TRUE_;

--- a/test_roft.ini
+++ b/test_roft.ini
@@ -1,0 +1,20 @@
+# Test configuration for ROFT model (alpha=0.1)
+# Basic LCDM parameters
+H0 = 67.5
+omega_b = 0.022
+omega_cdm = 0.12
+A_s = 2.1e-9
+n_s = 0.965
+tau_reio = 0.054
+
+# Outputs for quick checks
+write_background = yes
+output = tCl,mPk
+l_max_scalars = 1000
+P_k_max_h/Mpc = 3.0
+
+# ROFT extension
+alpha_roft = 0.1
+roft_model = add
+fluid_equation_of_state = ROFT
+root = output/roft_alpha0p1_


### PR DESCRIPTION
## Summary
- add ROFT dark-energy option with late-time clock parameter `alpha_roft`
- support ROFT background evolution via new equation-of-state case
- convert Lambda component to fluid when `alpha_roft` is non-zero

## Testing
- `make test_background`
- `./class roft.ini`

------
https://chatgpt.com/codex/tasks/task_e_68c506a38ef08333b73bdfdefd065ced