### PR TITLE
Document ROFT extension and add regression test

### DIFF
--- a/README_ROFT.md
+++ b/README_ROFT.md
@@ -1,0 +1,39 @@
+# ROFT extension for CLASS
+
+This branch adds a phenomenological late--time dark energy model where the fluid
+obeys
+\(w(a) = -1 + \alpha / [3 R(a)]\) with \(R(a) = 1 - \alpha \ln a\).
+The implementation introduces two new input parameters:
+
+- `alpha_roft` &mdash; controls the deviation from $\Lambda$CDM. Setting
+  `alpha_roft = 0` exactly reproduces $\Lambda$CDM.
+- `roft_model` &mdash; selects the variant of the model. At the moment only the
+  `add` model is implemented. A future `lapse` model is blocked by a safety
+  check.
+
+## Example run
+
+An example configuration is provided in `test_roft.ini`:
+
+```
+./class test_roft.ini
+```
+
+The file enables background and perturbation outputs for `alpha_roft = 0.1`.
+To compare with the $\Lambda$CDM limit set `alpha_roft = 0` in the same file.
+
+## Regression check
+
+A small script `scripts/test_roft_regression.py` runs CLASS twice and checks that
+`alpha_roft = 0` matches a pure $\Lambda$CDM run within $10^{-4}$ for the
+background expansion and CMB spectra:
+
+```
+python scripts/test_roft_regression.py
+```
+
+## Notes
+
+The code guards against negative values of $R(a)$; if this happens CLASS will
+stop with an error message. Only the `add` model affects the background and
+perturbations. The `lapse` option is reserved for future work.

--- a/explanatory.ini
+++ b/explanatory.ini
@@ -632,7 +632,8 @@ c_gamma_over_c_fld = 0.4
 # 8.a.2) Choose your equation of state between different models,
 #         - 'CLP' for p/rho = w0_fld + wa_fld (1-a/a0)
 #           (Chevalier-Linder-Polarski),
-#         - 'EDE' for early Dark Energy
+#         - 'EDE' for early Dark Energy,
+#         - 'ROFT' for Running Origin of Field Time (implemented models listed below)
 #      (default:'fluid_equation_of_state' set to 'CLP')
 fluid_equation_of_state = CLP
 
@@ -657,6 +658,10 @@ fluid_equation_of_state = CLP
 #w0_fld = -0.9
 #Omega_EDE = 0.
 #cs2_fld = 1
+
+# 8.a.2.3) ROFT extension parameters when 'ROFT' is selected
+#alpha_roft = 0.0   # Horloge tardive, alpha=0 => ΛCDM
+#roft_model = add   # add|lapse (seul add est implémenté)
 
 # 8.b) If Omega scalar field is different from 0
 

--- a/scripts/test_roft_regression.py
+++ b/scripts/test_roft_regression.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Check that alpha_roft = 0 reproduces LCDM."""
+import numpy as np
+import subprocess
+import tempfile
+import os
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.join(HERE, "..")
+CLASS = os.path.join(ROOT, "class")
+DEFAULT = os.path.join(ROOT, "default.ini")
+
+def run(extra, root):
+    cfg = open(DEFAULT).read().replace("write_background = no", "write_background = yes")
+    cfg += f"root = {root}\n"
+    cfg += extra
+    with tempfile.NamedTemporaryFile('w', suffix='.ini', delete=False) as f:
+        f.write(cfg)
+        name = f.name
+    subprocess.run([CLASS, name], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    os.remove(name)
+    return f"{root}00_background.dat", f"{root}00_cl.dat"
+
+def relmax(a, b):
+    return np.max(np.abs(a - b) / np.where(a != 0, a, 1))
+
+def main():
+    lcdm_bg, lcdm_cl = run("", os.path.join(ROOT, "output/reg_lcdm_"))
+    roft_bg, roft_cl = run("fluid_equation_of_state = ROFT\nalpha_roft = 0.\nroft_model = add\n", os.path.join(ROOT, "output/reg_roft0_"))
+    bg1 = np.loadtxt(lcdm_bg)
+    bg2 = np.loadtxt(roft_bg)
+    cl1 = np.loadtxt(lcdm_cl)
+    cl2 = np.loadtxt(roft_cl)
+    if relmax(bg1[:,3], bg2[:,3]) > 1e-4:
+        raise SystemExit("H(z) mismatch")
+    if relmax(bg1[:,5], bg2[:,5]) > 1e-4:
+        raise SystemExit("distance mismatch")
+    if relmax(cl1[:,1], cl2[:,1]) > 1e-4:
+        raise SystemExit("C_l mismatch")
+    print("ROFT regression passed")
+
+if __name__ == "__main__":
+    main()

--- a/test_roft.ini
+++ b/test_roft.ini
@@ -1,0 +1,20 @@
+# Test configuration for ROFT model (alpha=0.1)
+# Basic LCDM parameters
+H0 = 67.5
+omega_b = 0.022
+omega_cdm = 0.12
+A_s = 2.1e-9
+n_s = 0.965
+tau_reio = 0.054
+
+# Outputs for quick checks
+write_background = yes
+output = tCl,mPk
+l_max_scalars = 1000
+P_k_max_h/Mpc = 3.0
+
+# ROFT extension
+alpha_roft = 0.1
+roft_model = add
+fluid_equation_of_state = ROFT
+root = output/roft_alpha0p1_


### PR DESCRIPTION
## Summary
- document ROFT input parameters in explanatory.ini
- add example `test_roft.ini` and user guide `README_ROFT.md`
- provide regression script ensuring `alpha_roft=0` matches LCDM

## Testing
- `python scripts/test_roft_regression.py`
- Compared background and Cl outputs for `alpha_roft=0` vs `alpha_roft=0.1`

------
https://chatgpt.com/codex/tasks/task_e_68c50b7ade408333be0d8319538e360b