### PR TITLE
Allow ROFT fluid path for alpha_roft=0

### DIFF
--- a/README_ROFT.md
+++ b/README_ROFT.md
@@ -1,8 +1,7 @@
 # ROFT extension for CLASS
 
 This branch adds a phenomenological late--time dark energy model where the fluid
-obeys
-\(w(a) = -1 + \alpha / [3 R(a)]\) with \(R(a) = 1 - \alpha \ln a\).
+obeys \(w(a) = -1 + \alpha / [3 R(a)]\) with \(R(a) = 1 - \alpha \ln a\).
 The implementation introduces two new input parameters:
 
 - `alpha_roft` &mdash; controls the deviation from $\Lambda$CDM. Setting
@@ -10,6 +9,11 @@ The implementation introduces two new input parameters:
 - `roft_model` &mdash; selects the variant of the model. At the moment only the
   `add` model is implemented. A future `lapse` model is blocked by a safety
   check.
+
+Choosing `fluid_equation_of_state = ROFT` always promotes the cosmological
+constant to a dynamical fluid. When `alpha_roft = 0` this branch remains
+numerically identical to $\Lambda$CDM but runs through the `fld` code path for
+consistency.
 
 ## Example run
 

--- a/source/input.c
+++ b/source/input.c
@@ -3286,6 +3286,18 @@ int input_read_parameters_species(struct file_content * pfc,
                "alpha_roft leads to negative R(z) at z=%g",zmax);
   }
 
+  /* Allow specifying ROFT equation of state even when Omega0_fld = 0 */
+  if (pba->Omega0_fld == 0.) {
+    class_call(parser_read_string(pfc,"fluid_equation_of_state",&string1,&flag1,errmsg),
+               errmsg,
+               errmsg);
+    if (flag1 == _TRUE_) {
+      if ((strstr(string1,"ROFT") != NULL) || (strstr(string1,"roft") != NULL)) {
+        pba->fluid_equation_of_state = ROFT;
+      }
+    }
+  }
+
   /** 8.a) If Omega fluid is different from 0 */
   if (pba->Omega0_fld != 0.) {
     /** 8.a.1) PPF approximation */
@@ -3338,7 +3350,7 @@ int input_read_parameters_species(struct file_content * pfc,
   }
 
   /* Promote Lambda to fluid for ROFT */
-  if (pba->alpha_roft != 0.) {
+  if ((pba->alpha_roft != 0.) || (pba->fluid_equation_of_state == ROFT)) {
     pba->Omega0_fld += pba->Omega0_lambda;
     pba->Omega0_lambda = 0.;
     pba->fluid_equation_of_state = ROFT;


### PR DESCRIPTION
## Summary
- Promote Lambda to `fld` whenever `fluid_equation_of_state = ROFT` or `alpha_roft ≠ 0`
- Document that `alpha_roft = 0` still runs through the ROFT fluid path but is equivalent to ΛCDM

## Testing
- `make`
- `python scripts/test_roft_regression.py`


------
https://chatgpt.com/codex/tasks/task_e_68c50e041af48333b59ce1bd508ecb51